### PR TITLE
Align donation wrapped metrics with Creative Action cost conversions

### DIFF
--- a/client/src/components/donation/CountUpAnimation.tsx
+++ b/client/src/components/donation/CountUpAnimation.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
 import { motion } from "framer-motion";
 import { formatCurrency } from "@/lib/utils";
 
@@ -8,17 +8,37 @@ interface CountUpAnimationProps {
   delay?: number;
   className?: string;
   isCurrency?: boolean;
+  decimals?: number;
 }
 
-export default function CountUpAnimation({ 
+export default function CountUpAnimation({
   value,
   duration = 1.0, // Reduced default duration from 1.5 to 1.0 seconds for faster animations
   delay = 0,
   className = "",
-  isCurrency = false
+  isCurrency = false,
+  decimals
 }: CountUpAnimationProps) {
   const [count, setCount] = useState(0);
-  
+
+  const decimalPlaces = useMemo(() => {
+    if (decimals !== undefined) {
+      return decimals;
+    }
+
+    if (!Number.isFinite(value)) {
+      return 0;
+    }
+
+    const valueString = value.toString();
+    if (!valueString.includes(".")) {
+      return 0;
+    }
+
+    const fractionalLength = valueString.split(".")[1]?.length ?? 0;
+    return Math.min(2, fractionalLength);
+  }, [value, decimals]);
+
   useEffect(() => {
     // Guard against undefined or NaN values
     if (value === undefined || isNaN(value)) {
@@ -34,30 +54,32 @@ export default function CountUpAnimation({
       const animate = (timestamp: number) => {
         if (!startTime) startTime = timestamp;
         const progress = Math.min((timestamp - startTime) / (duration * 1000), 1);
-        
+
         // Use easeOutExpo for a nice effect when approaching the target value
         const easeOutExpo = 1 - Math.pow(2, -10 * progress);
-        setCount(Math.floor(easeOutExpo * value));
-        
+        const easedValue = easeOutExpo * value;
+        const nextValue = parseFloat(easedValue.toFixed(decimalPlaces));
+        setCount(nextValue);
+
         if (progress < 1) {
           animationFrameId = requestAnimationFrame(animate);
         } else {
           // Ensure we end at exactly the target value
-          setCount(value);
+          setCount(parseFloat(value.toFixed(decimalPlaces)));
         }
       };
-      
+
       animationFrameId = requestAnimationFrame(animate);
     }, delay * 1000);
-    
+
     return () => {
       clearTimeout(timeoutId);
       if (animationFrameId) {
         cancelAnimationFrame(animationFrameId);
       }
     };
-  }, [value, duration, delay]);
-  
+  }, [value, duration, delay, decimalPlaces]);
+
   // Use motion.span instead of motion.div to avoid nesting issues in paragraph elements
   return (
     <motion.span
@@ -72,8 +94,13 @@ export default function CountUpAnimation({
         repeatDelay: 3,
       }}
     >
-      {count !== undefined && count !== null ? 
-        (isCurrency ? formatCurrency(count) : count.toLocaleString()) 
+      {count !== undefined && count !== null
+        ? (isCurrency
+            ? formatCurrency(count)
+            : count.toLocaleString(undefined, {
+                minimumFractionDigits: decimalPlaces,
+                maximumFractionDigits: decimalPlaces,
+              }))
         : '0'}
     </motion.span>
   );

--- a/client/src/components/donation/DonorFinancialSlide.tsx
+++ b/client/src/components/donation/DonorFinancialSlide.tsx
@@ -1,5 +1,5 @@
 import { motion } from "framer-motion";
-import { DollarSign, TrendingUp } from "lucide-react";
+import { DollarSign, TrendingUp, Sparkles } from "lucide-react";
 import { DonationImpact } from "@/types/donation";
 import SlideLayout from "./SlideLayout";
 import CountUpAnimation from "./CountUpAnimation";
@@ -13,56 +13,70 @@ interface DonorFinancialSlideProps {
   isLastSlide?: boolean;
 }
 
-export default function DonorFinancialSlide({ 
-  impact,
-  amount,
-  onNext,
-  onPrevious,
-  isFirstSlide,
-  isLastSlide
-}: DonorFinancialSlideProps) {
-  
-  // Container and item variants for staggered animation
-  const containerVariants = {
-    hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.2,
-        delayChildren: 0.3
-      }
+export default function DonorFinancialSlide({ impact, amount, onNext, onPrevious, isFirstSlide, isLastSlide }: DonorFinancialSlideProps) {
+  const {
+    studentsSupported,
+    dayCampExperiences,
+    afterSchoolMonthsFunded,
+    residencyStudentsFunded,
+    averageStudentCost,
+  } = impact;
+
+  const studentCountDecimals = studentsSupported >= 10 ? 0 : 1;
+
+  const conversionMetrics = [
+    {
+      label: "Creative Camp Days",
+      description: "$75 = one child attends a Creative Action day camp.",
+      value: dayCampExperiences,
+    },
+    {
+      label: "Months of After-School",
+      description: "$345 = one month of after-school programming for a student.",
+      value: afterSchoolMonthsFunded,
+    },
+    {
+      label: "Year-Long Residencies",
+      description: "$486 = a student's theatre + digital media residency at Campbell.",
+      value: residencyStudentsFunded,
+    },
+  ];
+
+  const formatImpactNumber = (value: number) => {
+    if (!Number.isFinite(value)) {
+      return "0";
     }
+
+    if (value >= 10) {
+      return Math.round(value).toLocaleString();
+    }
+
+    return value.toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 1,
+    });
   };
-  
-  const itemVariants = {
-    hidden: { opacity: 0, y: 20 },
-    visible: { opacity: 1, y: 0, transition: { duration: 0.5 } }
-  };
-  
-  // Calculate financial metrics (leverage factor is how many times the donation is multiplied in value)
-  const leverageFactor = 6; // Updated to show $1 = $6 worth of groceries
-  const communityValue = amount * leverageFactor;
 
   return (
     <SlideLayout
       title="Financial Impact"
       variant="donor"
-      quote="Your donation goes further than you might think, creating ripple effects throughout our community."
+      quote="Every dollar you invest unlocks creative opportunities for young people across Central Texas."
       onNext={onNext}
       onPrevious={onPrevious}
       isFirstSlide={isFirstSlide}
       isLastSlide={isLastSlide}
     >
-      <div className="flex flex-col items-center mb-6">
+      <div className="flex flex-col items-center mb-6 space-y-4">
         <motion.div
           initial={{ scale: 0, rotate: -180 }}
           animate={{ scale: 1, rotate: 0 }}
           transition={{ duration: 0.5, type: "spring" }}
-          className="w-20 h-20 bg-[#f3fae7] rounded-full flex items-center justify-center mb-4"
+          className="w-20 h-20 bg-[#E8F5E9] rounded-full flex items-center justify-center"
         >
-          <DollarSign className="h-10 w-10 text-[#8dc53e]" />
+          <DollarSign className="h-10 w-10 text-[#43A047]" />
         </motion.div>
-        
+
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
@@ -70,53 +84,48 @@ export default function DonorFinancialSlide({
           className="text-center"
         >
           <h3 className="text-lg sm:text-xl text-[#414042] font-medium mb-2">
-            Your ${amount} donation creates
+            Your ${amount.toLocaleString()} donation directly supports approximately
           </h3>
-          <div className="text-3xl sm:text-4xl font-bold text-[#8dc53e]">
-            <CountUpAnimation
-              value={communityValue} 
-              isCurrency={true}
-              className="text-[#8dc53e]"
-            /> in community value
+          <div className="text-3xl sm:text-4xl font-bold text-[#43A047]">
+            <CountUpAnimation value={studentsSupported} decimals={studentCountDecimals} /> students
           </div>
           <p className="text-[#414042] mt-2 text-sm sm:text-base">
-            That's a {leverageFactor}x return on your investment!
+            Average cost per student experience ≈ ${averageStudentCost.toLocaleString()}.
           </p>
         </motion.div>
       </div>
-      
+
       <motion.div
-        className="space-y-4"
-        variants={containerVariants}
-        initial="hidden"
-        animate="visible"
-      >
-        <motion.div 
-          className="bg-white p-4 rounded-lg shadow-sm border border-gray-100"
-          variants={itemVariants}
-        >
-          <div className="flex items-start">
-            <div className="bg-[#f3fae7] p-2 rounded-full mr-3">
-              <TrendingUp className="h-5 w-5 text-[#8dc53e]" />
-            </div>
-            <div>
-              <h4 className="font-medium text-[#414042]">Economic Value</h4>
-              <p className="text-sm text-gray-600">
-                Every dollar you donate helps us secure and distribute ${leverageFactor} worth of groceries through our partnerships
-              </p>
-            </div>
-          </div>
-        </motion.div>
-      </motion.div>
-      
-      <motion.div
-        className="mt-6 bg-[#f3fae7] p-4 rounded-lg border border-[#8dc53e]/20 text-center"
+        className="grid grid-cols-1 md:grid-cols-3 gap-4"
         initial={{ opacity: 0, y: 20 }}
         animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 1.2, duration: 0.5 }}
+        transition={{ delay: 0.6, duration: 0.5 }}
       >
-        <p className="text-[#414042] text-sm">
-          Every dollar you donate helps us provide <span className="font-medium">${leverageFactor}</span> worth of nutritious groceries to families in need.
+        {conversionMetrics.map((metric) => (
+          <div key={metric.label} className="bg-white p-4 rounded-lg shadow-sm border border-gray-100">
+            <div className="flex items-start mb-3">
+              <div className="bg-[#E8F5E9] p-2 rounded-full mr-3">
+                <TrendingUp className="h-5 w-5 text-[#43A047]" />
+              </div>
+              <div>
+                <h4 className="font-medium text-[#414042]">{metric.label}</h4>
+                <p className="text-sm text-gray-600">{metric.description}</p>
+              </div>
+            </div>
+            <p className="text-3xl font-semibold text-[#43A047]">{formatImpactNumber(metric.value)}</p>
+          </div>
+        ))}
+      </motion.div>
+
+      <motion.div
+        className="mt-6 bg-[#E8F5E9] p-4 rounded-lg border border-[#43A047]/20 text-center"
+        initial={{ opacity: 0, y: 20 }}
+        animate={{ opacity: 1, y: 0 }}
+        transition={{ delay: 0.9, duration: 0.5 }}
+      >
+        <p className="text-[#414042] text-sm sm:text-base">
+          <Sparkles className="inline-block h-4 w-4 text-[#43A047] mr-1" aria-hidden />
+          You make tangible creative experiences possible — from camp days to year-long residencies.
         </p>
       </motion.div>
     </SlideLayout>

--- a/client/src/components/donation/DonorStudentsSlide.tsx
+++ b/client/src/components/donation/DonorStudentsSlide.tsx
@@ -12,29 +12,60 @@ interface DonorStudentsSlideProps {
   isLastSlide?: boolean;
 }
 
-export default function DonorStudentsSlide({ 
-  impact,
-  onNext,
-  onPrevious,
-  isFirstSlide,
-  isLastSlide
-}: DonorStudentsSlideProps) {
-  
-  // Container and item variants for staggered animation
-  const containerVariants = {
-    hidden: { opacity: 0 },
-    visible: {
-      opacity: 1,
-      transition: {
-        staggerChildren: 0.2,
-        delayChildren: 0.3
-      }
+export default function DonorStudentsSlide({ impact, onNext, onPrevious, isFirstSlide, isLastSlide }: DonorStudentsSlideProps) {
+  const {
+    studentsSupported,
+    studentsFullyFunded,
+    partialStudentPercentage,
+    dayCampExperiences,
+    afterSchoolMonthsFunded,
+    residencyStudentsFunded,
+    averageStudentCost,
+  } = impact;
+
+  const studentCountDecimals = studentsSupported >= 10 ? 0 : 1;
+  const formattedStudentsFullyFunded = studentsFullyFunded.toLocaleString();
+  const partialJourneyPercent = Math.max(1, Math.round(studentsSupported * 100));
+  const fundingSummary = studentsFullyFunded > 0
+    ? partialStudentPercentage > 0
+      ? `Fully funds ${formattedStudentsFullyFunded} student${studentsFullyFunded === 1 ? "" : "s"} and ${partialStudentPercentage}% of another student's journey.`
+      : `Fully funds ${formattedStudentsFullyFunded} student${studentsFullyFunded === 1 ? "" : "s"}.`
+    : `Covers ${partialJourneyPercent}% of a student's creative journey.`;
+
+  const conversionMetrics = [
+    {
+      icon: Pencil,
+      label: "Day Camp Experiences",
+      value: dayCampExperiences,
+      description: "$75 = one child attends a Creative Action day camp.",
+    },
+    {
+      icon: School,
+      label: "Months of After-School Programming",
+      value: afterSchoolMonthsFunded,
+      description: "$345 = one month of after-school programming for a student.",
+    },
+    {
+      icon: GraduationCap,
+      label: "Year-Long Residencies Funded",
+      value: residencyStudentsFunded,
+      description: "$486 = one student's full year of theatre + digital media residency at Campbell.",
+    },
+  ];
+
+  const formatImpactNumber = (value: number) => {
+    if (!Number.isFinite(value)) {
+      return "0";
     }
-  };
-  
-  const itemVariants = {
-    hidden: { opacity: 0, y: 20 },
-    visible: { opacity: 1, y: 0, transition: { duration: 0.5 } }
+
+    if (value >= 10) {
+      return Math.round(value).toLocaleString();
+    }
+
+    return value.toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 1,
+    });
   };
 
   return (
@@ -47,16 +78,16 @@ export default function DonorStudentsSlide({
       isFirstSlide={isFirstSlide}
       isLastSlide={isLastSlide}
     >
-      <div className="flex flex-col items-center mb-6">
+      <div className="flex flex-col items-center space-y-6">
         <motion.div
           initial={{ scale: 0, rotate: -180 }}
           animate={{ scale: 1, rotate: 0 }}
           transition={{ duration: 0.5, type: "spring" }}
-          className="w-20 h-20 bg-[#E3F2FD] rounded-full flex items-center justify-center mb-4"
+          className="w-20 h-20 bg-[#E3F2FD] rounded-full flex items-center justify-center mb-2"
         >
           <GraduationCap className="h-10 w-10 text-[#42A5F5]" />
         </motion.div>
-        
+
         <motion.div
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
@@ -67,69 +98,45 @@ export default function DonorStudentsSlide({
             Your donation reaches
           </h3>
           <div className="text-3xl sm:text-4xl font-bold text-[#6A1B9A]">
-            <CountUpAnimation
-              value={impact.studentsReached} 
-              isCurrency={false}
-              className="text-[#6A1B9A]"
-            /> students
+            <CountUpAnimation value={studentsSupported} decimals={studentCountDecimals} className="text-[#6A1B9A]" /> students
           </div>
-          <p className="text-[#414042] mt-2 text-sm sm:text-base">
-            That's equivalent to {impact.classroomComparison}!
+          <p className="text-[#414042] mt-2 text-sm sm:text-base">{impact.classroomComparison}</p>
+        </motion.div>
+
+        <motion.div
+          className="bg-[#EDE7F6] p-4 sm:p-5 rounded-lg border border-[#6A1B9A]/10 w-full"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.5, duration: 0.5 }}
+        >
+          <p className="text-center text-[#6A1B9A] text-sm sm:text-base">
+            Average cost per student experience: <span className="font-semibold">${averageStudentCost.toLocaleString()}</span>.
+            <span className="block mt-1 text-[#424242]">{fundingSummary}</span>
           </p>
         </motion.div>
+
+        <motion.div
+          className="w-full grid grid-cols-1 md:grid-cols-3 gap-4"
+          initial={{ opacity: 0 }}
+          animate={{ opacity: 1 }}
+          transition={{ delay: 0.7, duration: 0.5 }}
+        >
+          {conversionMetrics.map((metric) => (
+            <div key={metric.label} className="bg-white p-4 rounded-lg shadow-sm border border-gray-100">
+              <div className="flex items-start mb-3">
+                <div className="bg-[#E3F2FD] p-2 rounded-full mr-3">
+                  <metric.icon className="h-5 w-5 text-[#42A5F5]" />
+                </div>
+                <div>
+                  <h4 className="font-medium text-[#414042]">{metric.label}</h4>
+                  <p className="text-sm text-gray-600">{metric.description}</p>
+                </div>
+              </div>
+              <p className="text-3xl font-semibold text-[#6A1B9A]">{formatImpactNumber(metric.value)}</p>
+            </div>
+          ))}
+        </motion.div>
       </div>
-      
-      <motion.div 
-        className="bg-[#EDE7F6] p-4 sm:p-5 rounded-lg border border-[#6A1B9A]/10 w-full mb-4 mt-2"
-        initial={{ opacity: 0, y: 20 }}
-        animate={{ opacity: 1, y: 0 }}
-        transition={{ delay: 0.6, duration: 0.5 }}
-      >
-        <p className="text-center text-[#6A1B9A]">
-          Every $10 invested provides <span className="font-bold">1 hour of creative instruction</span> for students who need it most.
-        </p>
-      </motion.div>
-        
-      <motion.div
-        className="space-y-4"
-        variants={containerVariants}
-        initial="hidden"
-        animate="visible"
-      >
-        <motion.div 
-          className="bg-white p-4 rounded-lg shadow-sm border border-gray-100"
-          variants={itemVariants}
-        >
-          <div className="flex items-start">
-            <div className="bg-[#E3F2FD] p-2 rounded-full mr-3">
-              <Pencil className="h-5 w-5 text-[#42A5F5]" />
-            </div>
-            <div>
-              <h4 className="font-medium text-[#414042]">Creative Expression</h4>
-              <p className="text-sm text-gray-600">
-                {impact.programDistribution.afterSchool}% of students experience after-school arts programming with hands-on creative activities
-              </p>
-            </div>
-          </div>
-        </motion.div>
-        
-        <motion.div 
-          className="bg-white p-4 rounded-lg shadow-sm border border-gray-100"
-          variants={itemVariants}
-        >
-          <div className="flex items-start">
-            <div className="bg-[#EDE7F6] p-2 rounded-full mr-3">
-              <School className="h-5 w-5 text-[#6A1B9A]" />
-            </div>
-            <div>
-              <h4 className="font-medium text-[#414042]">School Partnerships</h4>
-              <p className="text-sm text-gray-600">
-                Creative Action serves {impact.programDistribution.schoolPartnership}% of students directly through in-school partnerships with teaching artists
-              </p>
-            </div>
-          </div>
-        </motion.div>
-      </motion.div>
     </SlideLayout>
   );
 }

--- a/client/src/components/donation/DonorSummarySlide.tsx
+++ b/client/src/components/donation/DonorSummarySlide.tsx
@@ -16,10 +16,10 @@ interface DonorSummarySlideProps {
   isLastSlide?: boolean;
 }
 
-export default function DonorSummarySlide({ 
-  amount, 
-  impact, 
-  onReset, 
+export default function DonorSummarySlide({
+  amount,
+  impact,
+  onReset,
   onShare,
   onNext,
   onPrevious,
@@ -27,23 +27,37 @@ export default function DonorSummarySlide({
   isLastSlide
 }: DonorSummarySlideProps) {
   const summaryRef = useRef<HTMLDivElement>(null);
-  
-  // Create a list of impact achievements
+
+  const formatImpactNumber = (value: number) => {
+    if (!Number.isFinite(value)) {
+      return "0";
+    }
+
+    if (value >= 10) {
+      return Math.round(value).toLocaleString();
+    }
+
+    return value.toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 1,
+    });
+  };
+
   const impactItems = [
-    { 
-      text: `Provided ${impact.mealsProvided.toLocaleString()} nutritious meals` 
-    },
-    { 
-      text: `Helped serve ${impact.peopleServed.toLocaleString()} people in need` 
-    },
-    { 
-      text: `Rescued ${impact.foodRescued.toLocaleString()} lbs of food` 
-    },
-    { 
-      text: `Prevented ${impact.co2Saved.toLocaleString()} lbs of CO2 emissions` 
+    {
+      text: `Invested in ${formatImpactNumber(impact.studentsSupported)} students' creative journeys`
     },
     {
-      text: `Saved ${impact.waterSaved.toLocaleString()} gallons of water`
+      text: `Made ${formatImpactNumber(impact.dayCampExperiences)} day camp experiences possible`
+    },
+    {
+      text: `Powered ${formatImpactNumber(impact.afterSchoolMonthsFunded)} months of after-school programming`
+    },
+    {
+      text: `Backed ${formatImpactNumber(impact.residencyStudentsFunded)} year-long residencies at Campbell`
+    },
+    {
+      text: `Average cost per student experience ≈ $${impact.averageStudentCost.toLocaleString()}`
     }
   ];
   
@@ -67,7 +81,7 @@ export default function DonorSummarySlide({
       <!DOCTYPE html>
       <html>
         <head>
-          <title>Your Impact Summary</title>
+          <title>Your Creative Impact Summary</title>
           <style>
             body {
               font-family: 'Open Sans', sans-serif;
@@ -153,13 +167,13 @@ export default function DonorSummarySlide({
         <body>
           <div class="certificate">
             <div class="impact-header">
-              <h1>Community Food Share Impact Certificate</h1>
-              <p>Presented to: <strong>Community Supporter</strong></p>
-              <p>For a generous donation of: <strong>$${amount.toLocaleString()}</strong></p>
-              <p class="date">${new Date().toLocaleDateString()}</p>
-            </div>
-            
-            <h2>Your donation's impact:</h2>
+            <h1>Creative Action Impact Certificate</h1>
+            <p>Presented to: <strong>Creative Action Supporter</strong></p>
+            <p>For a generous donation of: <strong>$${amount.toLocaleString()}</strong></p>
+            <p class="date">${new Date().toLocaleDateString()}</p>
+          </div>
+
+          <h2>Your donation's impact:</h2>
             
             <div class="impact-items">
               ${impactItems.map(item => `
@@ -172,8 +186,8 @@ export default function DonorSummarySlide({
           </div>
           
           <div class="footer">
-            <p>Community Food Share | Together, we're building a hunger-free community</p>
-            <p>Visit us at communityfoodshare.org</p>
+            <p>Creative Action | Where creativity meets possibility</p>
+            <p>Igniting the next generation of change makers through arts education</p>
           </div>
           
           <div class="no-print" style="margin-top: 2rem; text-align: center;">

--- a/client/src/components/donation/StudentsSlide.tsx
+++ b/client/src/components/donation/StudentsSlide.tsx
@@ -1,9 +1,8 @@
-import { useEffect, useRef } from "react";
-import { motion, useMotionValue, useTransform, animate } from "framer-motion";
+import { motion } from "framer-motion";
 import { DonationImpact } from "@/types/donation";
 import SlideLayout from "./SlideLayout";
-import { SLIDE_CONFIG } from "@/lib/constants";
 import { Pencil, GraduationCap, School } from "lucide-react";
+import CountUpAnimation from "./CountUpAnimation";
 
 interface StudentsSlideProps {
   impact: DonationImpact;
@@ -13,24 +12,61 @@ interface StudentsSlideProps {
   isLastSlide?: boolean;
 }
 
-export default function StudentsSlide({ 
-  impact,
-  onNext,
-  onPrevious,
-  isFirstSlide,
-  isLastSlide
-}: StudentsSlideProps) {
-  const count = useMotionValue(0);
-  const rounded = useTransform(count, (latest) => Math.round(latest));
+export default function StudentsSlide({ impact, onNext, onPrevious, isFirstSlide, isLastSlide }: StudentsSlideProps) {
+  const {
+    studentsSupported,
+    studentsFullyFunded,
+    partialStudentPercentage,
+    dayCampExperiences,
+    afterSchoolMonthsFunded,
+    residencyStudentsFunded,
+    averageStudentCost,
+  } = impact;
 
-  useEffect(() => {
-    const controls = animate(count, impact.studentsReached, {
-      duration: 2,
-      ease: "easeOut",
+  const studentCountDecimals = studentsSupported >= 10 ? 0 : 1;
+  const formattedStudentsFullyFunded = studentsFullyFunded.toLocaleString();
+  const partialJourneyPercent = Math.max(1, Math.round(studentsSupported * 100));
+  const fundingSummary = studentsFullyFunded > 0
+    ? partialStudentPercentage > 0
+      ? `Fully funds ${formattedStudentsFullyFunded} student${studentsFullyFunded === 1 ? "" : "s"} and ${partialStudentPercentage}% of another student's journey.`
+      : `Fully funds ${formattedStudentsFullyFunded} student${studentsFullyFunded === 1 ? "" : "s"}.`
+    : `Covers ${partialJourneyPercent}% of a student's creative journey.`;
+
+  const conversionMetrics = [
+    {
+      icon: Pencil,
+      label: "Day Camp Experiences",
+      value: dayCampExperiences,
+      description: "$75 = one child attends a Creative Action day camp.",
+    },
+    {
+      icon: School,
+      label: "Months of After-School Programming",
+      value: afterSchoolMonthsFunded,
+      description: "$345 = one month of after-school programming for a student.",
+    },
+    {
+      icon: GraduationCap,
+      label: "Year-Long Residencies Funded",
+      value: residencyStudentsFunded,
+      description: "$486 = one student's full year of theatre + digital media residency at Campbell.",
+    },
+  ];
+
+  const formatImpactNumber = (value: number) => {
+    if (!Number.isFinite(value)) {
+      return "0";
+    }
+
+    if (value >= 10) {
+      return Math.round(value).toLocaleString();
+    }
+
+    return value.toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 1,
     });
-
-    return controls.stop;
-  }, [count, impact.studentsReached]);
+  };
 
   return (
     <SlideLayout
@@ -42,75 +78,62 @@ export default function StudentsSlide({
       isFirstSlide={isFirstSlide}
       isLastSlide={isLastSlide}
     >
-      <div className="flex flex-col items-center space-y-5">
+      <div className="flex flex-col items-center space-y-6">
         <motion.div
           initial={{ scale: 0, rotate: -180 }}
           animate={{ scale: 1, rotate: 0 }}
-          transition={{ 
-            type: "spring", 
-            stiffness: 260, 
-            damping: 20, 
-            delay: 0.3 
-          }}
+          transition={{ type: "spring", stiffness: 260, damping: 20, delay: 0.2 }}
         >
           <GraduationCap className="h-16 w-16 text-[#42A5F5] mb-3" />
         </motion.div>
-        
-        <div className="text-center">
-          <p className="text-lg font-semibold text-[#424242]">Your donation reaches</p>
-          <p className="text-4xl font-bold text-[#6A1B9A]">
-            <motion.span>{rounded}</motion.span> Students
-          </p>
-          <p className="text-sm text-[#424242] mt-2">
-            That's equivalent to {impact.classroomComparison}!
-          </p>
-        </div>
-        
-        <motion.div 
-          className="bg-[#EDE7F6] p-4 sm:p-5 rounded-lg border border-[#6A1B9A]/10 w-full mt-4"
+
+        <motion.div
+          className="text-center"
           initial={{ opacity: 0, y: 20 }}
           animate={{ opacity: 1, y: 0 }}
-          transition={{ delay: 1, duration: 0.5 }}
+          transition={{ delay: 0.4, duration: 0.5 }}
         >
-          <p className="text-center text-[#6A1B9A]">
-            Your donation provides {impact.instructionHours} hours of creative instruction.
-            <span className="block mt-1 font-medium">Each hour reaches approximately 5 students with arts education.</span>
+          <p className="text-lg font-semibold text-[#424242]">Your donation fuels creative journeys for</p>
+          <p className="text-4xl font-bold text-[#6A1B9A]">
+            <CountUpAnimation value={studentsSupported} decimals={studentCountDecimals} /> students
+          </p>
+          <p className="text-sm text-[#424242] mt-2">{impact.classroomComparison}</p>
+        </motion.div>
+
+        <motion.div
+          className="bg-[#EDE7F6] p-4 sm:p-5 rounded-lg border border-[#6A1B9A]/10 w-full"
+          initial={{ opacity: 0, y: 20 }}
+          animate={{ opacity: 1, y: 0 }}
+          transition={{ delay: 0.6, duration: 0.5 }}
+        >
+          <p className="text-center text-[#6A1B9A] text-sm sm:text-base">
+            Average cost per student experience: <span className="font-semibold">${averageStudentCost.toLocaleString()}</span>.
+            <span className="block mt-1 text-[#424242]">{fundingSummary}</span>
           </p>
         </motion.div>
-        
+
         <motion.div
-          className="w-full mt-4 grid grid-cols-1 md:grid-cols-2 gap-4"
+          className="w-full grid grid-cols-1 md:grid-cols-3 gap-4"
           initial={{ opacity: 0 }}
           animate={{ opacity: 1 }}
-          transition={{ delay: 1.5, duration: 0.5 }}
+          transition={{ delay: 0.8, duration: 0.5 }}
         >
-          <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-100">
-            <div className="flex items-start">
-              <div className="bg-[#E3F2FD] p-2 rounded-full mr-3">
-                <Pencil className="h-5 w-5 text-[#42A5F5]" />
+          {conversionMetrics.map((metric) => (
+            <div key={metric.label} className="bg-white p-4 rounded-lg shadow-sm border border-gray-100">
+              <div className="flex items-start mb-3">
+                <div className="bg-[#E3F2FD] p-2 rounded-full mr-3">
+                  <metric.icon className="h-5 w-5 text-[#42A5F5]" />
+                </div>
+                <div>
+                  <h4 className="font-medium text-[#424242]">{metric.label}</h4>
+                  <p className="text-sm text-gray-600">{metric.description}</p>
+                </div>
               </div>
-              <div>
-                <h4 className="font-medium text-[#424242]">Creative Expression</h4>
-                <p className="text-sm text-gray-600">
-                  Students express themselves through various art forms and creative media
-                </p>
-              </div>
+              <p className="text-3xl font-semibold text-[#6A1B9A]">
+                {formatImpactNumber(metric.value)}
+              </p>
             </div>
-          </div>
-          
-          <div className="bg-white p-4 rounded-lg shadow-sm border border-gray-100">
-            <div className="flex items-start">
-              <div className="bg-[#E8EAF6] p-2 rounded-full mr-3">
-                <School className="h-5 w-5 text-[#6A1B9A]" />
-              </div>
-              <div>
-                <h4 className="font-medium text-[#424242]">Critical Thinking</h4>
-                <p className="text-sm text-gray-600">
-                  Arts education develops problem-solving skills and cognitive abilities
-                </p>
-              </div>
-            </div>
-          </div>
+          ))}
         </motion.div>
       </div>
     </SlideLayout>

--- a/client/src/components/donation/SummarySlide.tsx
+++ b/client/src/components/donation/SummarySlide.tsx
@@ -17,10 +17,10 @@ interface SummarySlideProps {
   isLastSlide?: boolean;
 }
 
-export default function SummarySlide({ 
-  amount, 
-  impact, 
-  onReset, 
+export default function SummarySlide({
+  amount,
+  impact,
+  onReset,
   onShare,
   onNext,
   onPrevious,
@@ -28,23 +28,37 @@ export default function SummarySlide({
   isLastSlide
 }: SummarySlideProps) {
   const summaryRef = useRef<HTMLDivElement>(null);
-  
-  // Create a list of Creative Action impact achievements
+
+  const formatImpactNumber = (value: number) => {
+    if (!Number.isFinite(value)) {
+      return "0";
+    }
+
+    if (value >= 10) {
+      return Math.round(value).toLocaleString();
+    }
+
+    return value.toLocaleString(undefined, {
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 1,
+    });
+  };
+
   const impactItems = [
-    { 
-      text: `Supported ${impact.instructionHours.toLocaleString()} hours of creative instruction` 
-    },
-    { 
-      text: `Reached ${impact.studentsReached.toLocaleString()} students with arts education` 
-    },
-    { 
-      text: `Funded ${impact.teachingArtistHours.toLocaleString()} teaching artist hours` 
-    },
-    { 
-      text: `Supported ${impact.selStudents.toLocaleString()} students with social-emotional learning` 
+    {
+      text: `Invested in ${formatImpactNumber(impact.studentsSupported)} students' creative journeys`
     },
     {
-      text: `Helped create ${impact.muralsSupported.toLocaleString()} community murals`
+      text: `Made ${formatImpactNumber(impact.dayCampExperiences)} day camp experiences possible`
+    },
+    {
+      text: `Powered ${formatImpactNumber(impact.afterSchoolMonthsFunded)} months of after-school programming`
+    },
+    {
+      text: `Backed ${formatImpactNumber(impact.residencyStudentsFunded)} year-long residencies at Campbell`
+    },
+    {
+      text: `Average cost per student experience ≈ $${impact.averageStudentCost.toLocaleString()}`
     }
   ];
   

--- a/client/src/components/donation/TimeGivingSlide.tsx
+++ b/client/src/components/donation/TimeGivingSlide.tsx
@@ -23,6 +23,7 @@ import {
   Gift
 } from "lucide-react";
 import CountUpAnimation from "./CountUpAnimation";
+import { CREATIVE_ACTION_DATA } from "@/lib/constants";
 
 interface TimeGivingSlideProps {
   impact: DonationImpact;
@@ -379,8 +380,8 @@ export default function TimeGivingSlide({
     const lifetimeAmount = totalFromFiscalYears > 0 ? totalFromFiscalYears : (donorSummary?.lifetimeGiving || 0);
     
     // Calculate estimates based on actual data when available
-    const studentsPerDollar = 0.5; // Each dollar helps reach approximately 0.5 students
-    const estimatedStudentsReached = Math.round(lifetimeAmount * studentsPerDollar);
+    const studentsPerDollar = 1 / CREATIVE_ACTION_DATA.averageStudentCost;
+    const estimatedStudentsReached = Math.round(lifetimeAmount * studentsPerDollar * 10) / 10;
     const estimatedTeachingArtistsSupported = Math.round(estimatedStudentsReached / 30); // Assume each teaching artist reaches 30 students
     const estimatedPrograms = Math.max(Math.round(lifetimeAmount / 1000), 1); // Estimate number of programs supported
     const estimatedCreativeHours = Math.max(actualYears * 10, 10); // Estimate creative hours enabled

--- a/client/src/components/donation/backup/TimeGivingSlide.tsx
+++ b/client/src/components/donation/backup/TimeGivingSlide.tsx
@@ -1,6 +1,6 @@
 import { useEffect, useState } from "react";
 import { DonationImpact } from "@/types/donation";
-import SlideLayout from "./SlideLayout";
+import SlideLayout from "../SlideLayout";
 import { formatCurrency } from "@/lib/utils";
 import { apiRequest } from "@/lib/queryClient";
 import { Button } from "@/components/ui/button";
@@ -22,7 +22,7 @@ import {
   Rocket,
   Gift
 } from "lucide-react";
-import CountUpAnimation from "./CountUpAnimation";
+import CountUpAnimation from "../CountUpAnimation";
 
 interface TimeGivingSlideProps {
   impact: DonationImpact;

--- a/client/src/hooks/use-donation-impact.ts
+++ b/client/src/hooks/use-donation-impact.ts
@@ -86,7 +86,7 @@ export function useDonationImpact() {
           amount,
           impact: data.impact,
           isLoading: false,
-          step: SlideNames.MEALS, // Move directly to the first content slide
+          step: SlideNames.STUDENTS, // Move directly to the first content slide
           donorEmail: data.donation.email || null
         }));
         
@@ -132,7 +132,7 @@ export function useDonationImpact() {
         ...prev,
         impact,
         isLoading: false,
-        step: SlideNames.MEALS
+        step: SlideNames.STUDENTS
       }));
       
       // Log the donation with email if provided
@@ -163,7 +163,7 @@ export function useDonationImpact() {
   const goToPreviousSlide = () => {
     setState(prev => {
       // If we're at the first content slide or earlier, don't go back
-      if (prev.step <= SlideNames.MEALS) {
+      if (prev.step <= SlideNames.STUDENTS) {
         return prev;
       }
       return { ...prev, step: prev.step - 1 };
@@ -187,7 +187,7 @@ export function useDonationImpact() {
 
   // Check if current slide is the first content slide
   const isFirstSlide = () => {
-    return state.step <= SlideNames.MEALS;
+    return state.step <= SlideNames.STUDENTS;
   };
 
   // Check if current slide is the last slide

--- a/client/src/lib/constants.ts
+++ b/client/src/lib/constants.ts
@@ -6,6 +6,12 @@ export const CREATIVE_ACTION_DATA = {
   costPerSELModule: 25, // $25 per student for social-emotional learning module
   costPerTheaterWorkshop: 30, // $30 per student participation in workshop session
   costPerBraveSchoolsLesson: 100, // $100 per Brave Schools class lesson
+
+  // Core conversion metrics highlighted in the 2024 wrapped
+  averageStudentCost: 142, // ~$142 to support a student for the year
+  dayCampCost: 75, // $75 sends a child to day camp
+  afterSchoolMonthlyCost: 345, // $345 funds a month of after-school programming
+  residencyCost: 486, // $486 supports a full-year residency at Campbell
   
   // Program distribution
   programAreas: {

--- a/client/src/lib/donation-calculator.ts
+++ b/client/src/lib/donation-calculator.ts
@@ -3,40 +3,35 @@ import { CREATIVE_ACTION_DATA } from "./constants";
 
 // Generate creative impact description based on donation amount
 function generateImpactDescription(amount: number): string {
-  if (amount < 25) {
-    return "Your donation provides vital art supplies for creative expression.";
-  } else if (amount < 50) {
-    return "You're helping students explore their creative talents and build confidence!";
-  } else if (amount < 100) {
-    return "Your gift supports teaching artists who inspire the next generation.";
-  } else if (amount < 250) {
-    return "You're making social-emotional learning through arts possible for so many students!";
-  } else if (amount < 500) {
-    return "Your generosity helps create safe spaces for youth to express themselves.";
-  } else if (amount < 1000) {
-    return "You're helping transform communities through collaborative art projects!";
+  if (amount < 50) {
+    return "Your donation provides vital art supplies and creative materials.";
+  } else if (amount < CREATIVE_ACTION_DATA.dayCampCost) {
+    return "You're helping a student get one step closer to camp this year.";
+  } else if (amount < CREATIVE_ACTION_DATA.averageStudentCost) {
+    return "You just sent a student to a full day of Creative Action camp!";
+  } else if (amount < CREATIVE_ACTION_DATA.afterSchoolMonthlyCost) {
+    return "You're covering a student's core creative learning experience for the year.";
+  } else if (amount < CREATIVE_ACTION_DATA.residencyCost) {
+    return "You're funding a full month of after-school programming for a student.";
+  } else if (amount < CREATIVE_ACTION_DATA.residencyCost * 2) {
+    return "You just underwrote a year-long arts residency for a student at Campbell.";
   } else {
-    return "Your extraordinary gift is helping create lasting change through arts education!";
+    return "Your extraordinary gift funds multiple year-long residencies for emerging creatives!";
   }
 }
 
-// Generate classroom size comparison based on students reached
-function generateClassroomComparison(students: number): string {
-  if (students < 10) {
-    return `a small group workshop (${students} students)`;
-  } else if (students < 25) {
-    return `a typical classroom (${students} students)`;
-  } else if (students < 60) {
-    return `${Math.round(students / 25)} typical classrooms (${students} students)`;
-  } else if (students < 150) {
-    return `a small school assembly (${students} students)`;
-  } else if (students < 500) {
-    return `a large school assembly (${students} students)`;
-  } else if (students < 1000) {
-    return `an entire small school (${students} students)`;
-  } else {
-    return `multiple school communities (${students} students)`;
+// Generate summary text for student experiences
+function generateStudentExperienceSummary(students: number): string {
+  if (students >= 10) {
+    return `${Math.round(students).toLocaleString()} students' creative journeys`;
   }
+
+  if (students >= 1) {
+    return `${students.toFixed(1)} students' creative journeys`;
+  }
+
+  const percentage = Math.max(1, Math.round(students * 100));
+  return `${percentage}% of a student's creative journey`;
 }
 
 export function calculateDonationImpact(amount: number): DonationImpact {
@@ -48,16 +43,28 @@ export function calculateDonationImpact(amount: number): DonationImpact {
   const theaterStudents = Math.round(amount / CREATIVE_ACTION_DATA.costPerTheaterWorkshop);
   const braveSchoolsLessons = Math.round(amount / CREATIVE_ACTION_DATA.costPerBraveSchoolsLesson);
   
-  // Calculate students reached using the instruction hours metric
-  const studentsReached = Math.round(instructionHours * CREATIVE_ACTION_DATA.studentsPerInstructionHour);
-  
+  // Core conversions for the wrapped experience
+  const studentsSupportedRaw = amount / CREATIVE_ACTION_DATA.averageStudentCost;
+  const studentsSupported = Number(studentsSupportedRaw.toFixed(2));
+  const studentsFullyFunded = Math.floor(studentsSupportedRaw);
+  const partialStudentPercentage = studentsSupportedRaw > studentsFullyFunded
+    ? Math.round((studentsSupportedRaw - studentsFullyFunded) * 100)
+    : 0;
+
+  const dayCampExperiences = Number((amount / CREATIVE_ACTION_DATA.dayCampCost).toFixed(2));
+  const afterSchoolMonthsFunded = Number((amount / CREATIVE_ACTION_DATA.afterSchoolMonthlyCost).toFixed(2));
+  const residencyStudentsFunded = Number((amount / CREATIVE_ACTION_DATA.residencyCost).toFixed(2));
+
+  // Calculate students reached based on the new average cost metric
+  const studentsReached = Number(studentsSupported.toFixed(2));
+
   // Calculate percentage of total students served annually
-  const studentPercentage = ((studentsReached / CREATIVE_ACTION_DATA.studentsPerYear) * 100).toFixed(2) + '%';
-  
+  const studentPercentage = ((studentsReached / CREATIVE_ACTION_DATA.studentsPerYear) * 100).toFixed(3) + '%';
+
   // Generate text descriptions
   const impactDescription = generateImpactDescription(amount);
-  const classroomComparison = generateClassroomComparison(studentsReached);
-  
+  const classroomComparison = generateStudentExperienceSummary(studentsSupportedRaw);
+
   // Map these metrics to the expected return type for now
   // Some properties are kept for backward compatibility
   return {
@@ -73,6 +80,14 @@ export function calculateDonationImpact(amount: number): DonationImpact {
     impactDescription,
     classroomComparison,
     programDistribution: CREATIVE_ACTION_DATA.programAreas,
+
+    averageStudentCost: CREATIVE_ACTION_DATA.averageStudentCost,
+    studentsSupported,
+    studentsFullyFunded,
+    partialStudentPercentage,
+    dayCampExperiences,
+    afterSchoolMonthsFunded,
+    residencyStudentsFunded,
     
     // Required fields for backward compatibility
     mealsProvided: instructionHours, // Repurposing meals as instruction hours

--- a/client/src/pages/VolunteerImpact.tsx
+++ b/client/src/pages/VolunteerImpact.tsx
@@ -700,7 +700,9 @@ const LoadingSlide = () => (
             transition={{ delay: 1.2, duration: 0.5 }}
             className="mt-6"
           >
-            <CFSLogo height={40} />
+            <p className="text-lg font-semibold text-[#6A1B9A] tracking-wide uppercase">
+              Creative Action
+            </p>
           </motion.div>
         </motion.div>
       </CardContent>
@@ -1280,7 +1282,9 @@ const IntroSlide = ({
             transition={{ delay: 1.0, duration: 0.5 }}
             className="mt-6 flex justify-center"
           >
-            <CFSLogo height={40} />
+            <p className="text-lg font-semibold text-[#6A1B9A] tracking-wide uppercase">
+              Creative Action
+            </p>
           </motion.div>
         </CardContent>
       </Card>
@@ -1393,14 +1397,16 @@ const ThankYouSlide = ({ hours, onReset, onShare, onPrevious, isFirstSlide, isLa
             </p>
           </motion.div>
           
-          {/* Add CFS Logo */}
+          {/* Creative Action brand text */}
           <motion.div
             initial={{ opacity: 0 }}
             animate={{ opacity: 1 }}
             transition={{ delay: 1.4, duration: 0.5 }}
             className="w-full flex justify-end mt-4 mb-2"
           >
-            <CFSLogo height={40} />
+            <p className="text-base font-semibold text-[#6A1B9A] tracking-wide uppercase">
+              Creative Action
+            </p>
           </motion.div>
           
           <motion.div 

--- a/client/src/types/donation.ts
+++ b/client/src/types/donation.ts
@@ -34,6 +34,15 @@ export interface DonationImpact {
     youthTheater: number;
     schoolPartnership: number;
   };
+
+  // Core cost conversion metrics for the 2024 wrapped
+  averageStudentCost: number;
+  studentsSupported: number;
+  studentsFullyFunded: number;
+  partialStudentPercentage: number;
+  dayCampExperiences: number;
+  afterSchoolMonthsFunded: number;
+  residencyStudentsFunded: number;
   
   // Legacy fields kept for compatibility with existing components
   mealsProvided: number;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -36,7 +36,11 @@ export function calculateDonationImpact(amount: number) {
   const costPerBraveSchoolsLesson = 100; // $100 per Brave Schools class lesson
   const studentsPerInstructionHour = 5; // Each hour of instruction reaches about 5 students
   const studentsPerYear = 15000; // Approximate number of students served annually
-  
+  const averageStudentCost = 142; // Average annual cost to serve one student
+  const dayCampCost = 75; // $75 sends a child to a day camp day
+  const afterSchoolMonthlyCost = 345; // $345 funds a month of after-school programming
+  const residencyCost = 486; // $486 supports a year-long residency at Campbell
+
   // Calculate impact metrics
   const instructionHours = Math.round(amount / costPerCreativeInstructionHour);
   const muralsSupported = Math.max(1, Math.round(amount / costPerMuralSupplies));
@@ -44,47 +48,52 @@ export function calculateDonationImpact(amount: number) {
   const selStudents = Math.round(amount / costPerSELModule);
   const theaterStudents = Math.round(amount / costPerTheaterWorkshop);
   const braveSchoolsLessons = Math.round(amount / costPerBraveSchoolsLesson);
-  
-  // Calculate students reached using the instruction hours metric
-  const studentsReached = Math.round(instructionHours * studentsPerInstructionHour);
-  
+
+  // Core wrapped conversions
+  const studentsSupportedRaw = amount / averageStudentCost;
+  const studentsSupported = Number(studentsSupportedRaw.toFixed(2));
+  const studentsFullyFunded = Math.floor(studentsSupportedRaw);
+  const partialStudentPercentage = studentsSupportedRaw > studentsFullyFunded
+    ? Math.round((studentsSupportedRaw - studentsFullyFunded) * 100)
+    : 0;
+
+  const dayCampExperiences = Number((amount / dayCampCost).toFixed(2));
+  const afterSchoolMonthsFunded = Number((amount / afterSchoolMonthlyCost).toFixed(2));
+  const residencyStudentsFunded = Number((amount / residencyCost).toFixed(2));
+
+  // Calculate students reached based on the new average cost metric
+  const studentsReached = Number(studentsSupported.toFixed(2));
+
   // Calculate percentage of total students served annually
-  const studentPercentage = ((studentsReached / studentsPerYear) * 100).toFixed(2) + '%';
-  
-  // Generate classroom size comparison
+  const studentPercentage = ((studentsReached / studentsPerYear) * 100).toFixed(3) + '%';
+
+  // Generate student experience summary
   let classroomComparison = "";
-  if (studentsReached < 10) {
-    classroomComparison = `a small group workshop (${studentsReached} students)`;
-  } else if (studentsReached < 25) {
-    classroomComparison = `a typical classroom (${studentsReached} students)`;
-  } else if (studentsReached < 60) {
-    classroomComparison = `${Math.round(studentsReached / 25)} typical classrooms (${studentsReached} students)`;
-  } else if (studentsReached < 150) {
-    classroomComparison = `a small school assembly (${studentsReached} students)`;
-  } else if (studentsReached < 500) {
-    classroomComparison = `a large school assembly (${studentsReached} students)`;
-  } else if (studentsReached < 1000) {
-    classroomComparison = `an entire small school (${studentsReached} students)`;
+  if (studentsSupportedRaw >= 10) {
+    classroomComparison = `${Math.round(studentsSupportedRaw).toLocaleString()} students' creative journeys`;
+  } else if (studentsSupportedRaw >= 1) {
+    classroomComparison = `${studentsSupportedRaw.toFixed(1)} students' creative journeys`;
   } else {
-    classroomComparison = `multiple school communities (${studentsReached} students)`;
+    const percentage = Math.max(1, Math.round(studentsSupportedRaw * 100));
+    classroomComparison = `${percentage}% of a student's creative journey`;
   }
-  
+
   // Generate impact description
   let impactDescription = "";
-  if (amount < 25) {
-    impactDescription = "Your donation provides vital art supplies for creative expression.";
-  } else if (amount < 50) {
-    impactDescription = "You're helping students explore their creative talents and build confidence!";
-  } else if (amount < 100) {
-    impactDescription = "Your gift supports teaching artists who inspire the next generation.";
-  } else if (amount < 250) {
-    impactDescription = "You're making social-emotional learning through arts possible for so many students!";
-  } else if (amount < 500) {
-    impactDescription = "Your generosity helps create safe spaces for youth to express themselves.";
-  } else if (amount < 1000) {
-    impactDescription = "You're helping transform communities through collaborative art projects!";
+  if (amount < 50) {
+    impactDescription = "Your donation provides vital art supplies and creative materials.";
+  } else if (amount < dayCampCost) {
+    impactDescription = "You're helping a student get one step closer to camp this year.";
+  } else if (amount < averageStudentCost) {
+    impactDescription = "You just sent a student to a full day of Creative Action camp!";
+  } else if (amount < afterSchoolMonthlyCost) {
+    impactDescription = "You're covering a student's core creative learning experience for the year.";
+  } else if (amount < residencyCost) {
+    impactDescription = "You're funding a full month of after-school programming for a student.";
+  } else if (amount < residencyCost * 2) {
+    impactDescription = "You just underwrote a year-long arts residency for a student at Campbell.";
   } else {
-    impactDescription = "Your extraordinary gift is helping create lasting change through arts education!";
+    impactDescription = "Your extraordinary gift funds multiple year-long residencies for emerging creatives!";
   }
   
   // Program distribution data
@@ -111,6 +120,14 @@ export function calculateDonationImpact(amount: number) {
     impactDescription,
     classroomComparison,
     programDistribution,
+
+    averageStudentCost,
+    studentsSupported,
+    studentsFullyFunded,
+    partialStudentPercentage,
+    dayCampExperiences,
+    afterSchoolMonthsFunded,
+    residencyStudentsFunded,
     
     // Required fields for backward compatibility
     mealsProvided: instructionHours, // Repurposing meals as instruction hours

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -108,6 +108,15 @@ export type DonationImpact = {
     youthTheater: number;
     schoolPartnership: number;
   };
+
+  // Core cost conversion metrics for the 2024 wrapped experience
+  averageStudentCost: number;
+  studentsSupported: number;
+  studentsFullyFunded: number;
+  partialStudentPercentage: number;
+  dayCampExperiences: number;
+  afterSchoolMonthsFunded: number;
+  residencyStudentsFunded: number;
   
   // Legacy fields kept for compatibility with existing components
   mealsProvided: number;
@@ -125,16 +134,16 @@ export type DonationImpact = {
   freshFoodPercentage: number;
   
   // Legacy comparison fields kept for compatibility
-  babyElephants?: string;
-  bison?: string;
-  cars?: string;
-  houseCats?: string;
-  goldenRetrievers?: string;
-  grizzlyBears?: string;
-  hippos?: string;
-  hippopotamus?: string;
-  schoolBuses?: string;
-  smallJets?: string;
+  babyElephants: string;
+  bison: string;
+  cars: string;
+  houseCats: string;
+  goldenRetrievers: string;
+  grizzlyBears: string;
+  hippos: string;
+  hippopotamus: string;
+  schoolBuses: string;
+  smallJets: string;
   breadLoaves?: string;
   pineapples?: string;
   toddlers?: string;


### PR DESCRIPTION
## Summary
- add the new cost-to-impact conversions (average student cost, camp days, after-school months, residencies) to the shared donation impact types and both calculator implementations so the wrapped reflects Creative Action’s latest stats
- refresh the student-, financial-, and summary-focused slides (including donor variants) to feature the new metrics, improved number formatting, and Creative Action-specific messaging
- update supporting components such as the donation journey hook, time-giving slide, and volunteer impact branding to stay consistent with the new slide order and Creative Action identity

## Testing
- npm run check *(fails: existing repository type errors in legacy components and import utilities)*

------
https://chatgpt.com/codex/tasks/task_e_68d6e15c563c8327b91743a2c267c6e4