### PR TITLE
Refine student support metrics

### DIFF
--- a/client/src/lib/donation-calculator.ts
+++ b/client/src/lib/donation-calculator.ts
@@ -47,7 +47,29 @@ export function calculateDonationImpact(amount: number): DonationImpact {
   const selStudents = Math.round(amount / CREATIVE_ACTION_DATA.costPerSELModule);
   const theaterStudents = Math.round(amount / CREATIVE_ACTION_DATA.costPerTheaterWorkshop);
   const braveSchoolsLessons = Math.round(amount / CREATIVE_ACTION_DATA.costPerBraveSchoolsLesson);
-  
+
+  // Calculate detailed student support metrics without rounding past actual impact
+  const studentsSupportedRaw = amount / CREATIVE_ACTION_DATA.costPerSELModule;
+  const epsilon = 1e-9;
+  let studentsFullyFunded = Math.floor(studentsSupportedRaw + epsilon);
+  let fractionalStudent = studentsSupportedRaw - studentsFullyFunded;
+
+  if (fractionalStudent >= 1 - epsilon) {
+    studentsFullyFunded += 1;
+    fractionalStudent = 0;
+  }
+
+  if (fractionalStudent <= epsilon) {
+    fractionalStudent = 0;
+  }
+
+  const partialPercentageHundredths =
+    fractionalStudent > 0 ? Math.floor(fractionalStudent * 10000) : 0;
+
+  const partialStudentPercentage = partialPercentageHundredths / 100;
+  const studentsSupported =
+    studentsFullyFunded + partialPercentageHundredths / 10000;
+
   // Calculate students reached using the instruction hours metric
   const studentsReached = Math.round(instructionHours * CREATIVE_ACTION_DATA.studentsPerInstructionHour);
   
@@ -68,6 +90,9 @@ export function calculateDonationImpact(amount: number): DonationImpact {
     selStudents,
     theaterStudents,
     braveSchoolsLessons,
+    studentsSupported,
+    studentsFullyFunded,
+    partialStudentPercentage,
     studentsReached,
     studentPercentage,
     impactDescription,

--- a/client/src/types/donation.ts
+++ b/client/src/types/donation.ts
@@ -22,6 +22,9 @@ export interface DonationImpact {
   selStudents: number;
   theaterStudents: number;
   braveSchoolsLessons: number;
+  studentsSupported: number;
+  studentsFullyFunded: number;
+  partialStudentPercentage: number;
   studentsReached: number;
   studentPercentage: string;
   impactDescription: string;

--- a/server/routes.ts
+++ b/server/routes.ts
@@ -44,7 +44,29 @@ export function calculateDonationImpact(amount: number) {
   const selStudents = Math.round(amount / costPerSELModule);
   const theaterStudents = Math.round(amount / costPerTheaterWorkshop);
   const braveSchoolsLessons = Math.round(amount / costPerBraveSchoolsLesson);
-  
+
+  // Calculate detailed student funding metrics using precise fractions
+  const studentsSupportedRaw = amount / costPerSELModule;
+  const epsilon = 1e-9;
+  let studentsFullyFunded = Math.floor(studentsSupportedRaw + epsilon);
+  let fractionalStudent = studentsSupportedRaw - studentsFullyFunded;
+
+  if (fractionalStudent >= 1 - epsilon) {
+    studentsFullyFunded += 1;
+    fractionalStudent = 0;
+  }
+
+  if (fractionalStudent <= epsilon) {
+    fractionalStudent = 0;
+  }
+
+  const partialPercentageHundredths =
+    fractionalStudent > 0 ? Math.floor(fractionalStudent * 10000) : 0;
+
+  const partialStudentPercentage = partialPercentageHundredths / 100;
+  const studentsSupported =
+    studentsFullyFunded + partialPercentageHundredths / 10000;
+
   // Calculate students reached using the instruction hours metric
   const studentsReached = Math.round(instructionHours * studentsPerInstructionHour);
   
@@ -106,6 +128,9 @@ export function calculateDonationImpact(amount: number) {
     selStudents,
     theaterStudents,
     braveSchoolsLessons,
+    studentsSupported,
+    studentsFullyFunded,
+    partialStudentPercentage,
     studentsReached,
     studentPercentage,
     impactDescription,

--- a/shared/schema.ts
+++ b/shared/schema.ts
@@ -96,6 +96,9 @@ export type DonationImpact = {
   selStudents: number;
   theaterStudents: number;
   braveSchoolsLessons: number;
+  studentsSupported: number;
+  studentsFullyFunded: number;
+  partialStudentPercentage: number;
   studentsReached: number;
   studentPercentage: string;
   impactDescription: string;


### PR DESCRIPTION
## Summary
- add precise student support calculations and new metrics to the client-side donation impact helper
- mirror the refined student funding logic on the server to keep API responses aligned
- extend the shared DonationImpact typings to expose the new student support fields for both environments

## Testing
- npm run check *(fails: pre-existing type errors in unrelated files)*

------
https://chatgpt.com/codex/tasks/task_e_68d70ddbc8fc8327b3e62bf36c01d14c